### PR TITLE
Improve tabs js logic

### DIFF
--- a/view/base/templates/script/component-partial/tab-component-partial.phtml
+++ b/view/base/templates/script/component-partial/tab-component-partial.phtml
@@ -19,6 +19,7 @@ use Magento\Framework\View\Element\Template;
             this.$root.querySelectorAll('[data-tab-id]').forEach(tab => {
                 tab.classList.remove('tab-active');
                 tab.classList.add('tab-inactive');
+                tab.removeAttribute('disabled');
             });
 
             this.$root.querySelectorAll('[data-tab-content]').forEach(tabContent => {
@@ -30,6 +31,7 @@ use Magento\Framework\View\Element\Template;
             if (activeTab) {
                 activeTab.classList.remove('tab-inactive');
                 activeTab.classList.add('tab-active');
+                activeTab.setAttribute('disabled', '');
             }
             // @todo: Save active tab in session
 

--- a/view/base/templates/script/component-partial/tab-component-partial.phtml
+++ b/view/base/templates/script/component-partial/tab-component-partial.phtml
@@ -17,8 +17,8 @@ use Magento\Framework\View\Element\Template;
         },
         toggleTab(tabId) {
             this.$root.querySelectorAll('[data-tab-id]').forEach(tab => {
-                tab.classList.remove('tab-active');
-                tab.classList.add('tab-inactive');
+                tab.classList.remove(this.activeTabClass);
+                tab.classList.add(this.inactiveTabClass);
                 tab.removeAttribute('disabled');
             });
 
@@ -29,8 +29,8 @@ use Magento\Framework\View\Element\Template;
 
             const activeTab = this.$root.querySelector('[data-tab-id="' + tabId + '"]');
             if (activeTab) {
-                activeTab.classList.remove('tab-inactive');
-                activeTab.classList.add('tab-active');
+                activeTab.classList.remove(this.inactiveTabClass);
+                activeTab.classList.add(this.activeTabClass);
                 activeTab.setAttribute('disabled', '');
             }
             // @todo: Save active tab in session


### PR DESCRIPTION
The tabs component should manage its state using HTML attributes (e.g., `aria-*` attributes) rather than relying on CSS classes. Ideally, the component's core logic should be implemented primarily with minimal JavaScript by leveraging a native HTML radio group structure, with JavaScript only handling the display or "open" state.